### PR TITLE
Update BatteryDrawer.java

### DIFF
--- a/app/src/main/java/com/androidexperiments/meter/drawers/BatteryDrawer.java
+++ b/app/src/main/java/com/androidexperiments/meter/drawers/BatteryDrawer.java
@@ -180,7 +180,7 @@ public class BatteryDrawer extends Drawer {
         int fgCircleColor = interpolateColor(color_foreground_decharge, color_foreground_charging, (float) lerp(_colorTransitionToCharged));
         fgCircleColor = interpolateColor(fgCircleColor, color_foreground_critical, (float) lerp(_colorTransitionToCritical));
         paint.setColor(fgCircleColor);
-        c.drawCircle((float)(x+c.getWidth()*pos.getX()),(float)(y+c.getWidth()*pos.getY()), _circleSize*batteryPct, paint);
+        c.drawCircle((float)(x+c.getWidth()*pos.getX()),(float)(y+c.getWidth()*pos.getY()), Math.sqrt(_circleSize*_circleSize*batteryPct), paint);
 
         // Text
         String label1 = "Battery " + Integer.toString(Math.round(batteryPct*100)) + "%";

--- a/app/src/main/java/com/androidexperiments/meter/drawers/BatteryDrawer.java
+++ b/app/src/main/java/com/androidexperiments/meter/drawers/BatteryDrawer.java
@@ -180,7 +180,7 @@ public class BatteryDrawer extends Drawer {
         int fgCircleColor = interpolateColor(color_foreground_decharge, color_foreground_charging, (float) lerp(_colorTransitionToCharged));
         fgCircleColor = interpolateColor(fgCircleColor, color_foreground_critical, (float) lerp(_colorTransitionToCritical));
         paint.setColor(fgCircleColor);
-        c.drawCircle((float)(x+c.getWidth()*pos.getX()),(float)(y+c.getWidth()*pos.getY()), Math.sqrt(_circleSize*_circleSize*batteryPct), paint);
+        c.drawCircle((float)(x+c.getWidth()*pos.getX()),(float)(y+c.getWidth()*pos.getY()), (float) Math.sqrt(_circleSize*_circleSize*batteryPct), paint);
 
         // Text
         String label1 = "Battery " + Integer.toString(Math.round(batteryPct*100)) + "%";


### PR DESCRIPTION
The battery life indicator is a circle within a circle.

The inner circle currently has its radius set to the battery life percentage of the radius of the overall circle.  Thus, when battery life is at 50%, the radius or diameter of the smaller circle is 50% of the radius or diameter of the overall circle.  This is not an accurate representation of battery life.  Instead, the AREA of the circles should represent the battery percentage left.  Remember pi r-squared is the area of a circle, so if square the radius of the large circle, multiply by the battery percentage, and then take the square root of that, we'll have a smaller circle which area is proportional to the larger circle according to the percentage battery life left.  This is a much more accurate indication of battery life.
