### PR TITLE
Use percentage of area instead of radius to display battery remaining.

### DIFF
--- a/app/src/main/java/com/androidexperiments/meter/drawers/BatteryDrawer.java
+++ b/app/src/main/java/com/androidexperiments/meter/drawers/BatteryDrawer.java
@@ -118,7 +118,7 @@ public class BatteryDrawer extends Drawer {
         pos = pos.add(vel);
 
         float dist = (float) pos.distance(new Vector2D(0,0));
-        float maxDist = (float) (circleSize-circleSize*batteryPct);
+        float maxDist = (float) (circleSize-innerCircleRadius(circleSize, batteryPct));
         if(dist > maxDist){
             Vector2D n = pos.normalize().scalarMultiply(-1);
             Vector2D reflection = vel.subtract(n.scalarMultiply(2*vel.dotProduct(n)));
@@ -180,7 +180,7 @@ public class BatteryDrawer extends Drawer {
         int fgCircleColor = interpolateColor(color_foreground_decharge, color_foreground_charging, (float) lerp(_colorTransitionToCharged));
         fgCircleColor = interpolateColor(fgCircleColor, color_foreground_critical, (float) lerp(_colorTransitionToCritical));
         paint.setColor(fgCircleColor);
-        c.drawCircle((float)(x+c.getWidth()*pos.getX()),(float)(y+c.getWidth()*pos.getY()), _circleSize*batteryPct, paint);
+        c.drawCircle((float)(x+c.getWidth()*pos.getX()),(float)(y+c.getWidth()*pos.getY()), (float)innerCircleRadius(_circleSize, batteryPct), paint);
 
         // Text
         String label1 = "Battery " + Integer.toString(Math.round(batteryPct*100)) + "%";
@@ -204,5 +204,13 @@ public class BatteryDrawer extends Drawer {
         int status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
         return status == BatteryManager.BATTERY_STATUS_CHARGING ||
                 status == BatteryManager.BATTERY_STATUS_FULL;
+    }
+
+    /**
+     * Calculate the inner circle radius so that its area is batteryPct times
+     * that of the outer circle.
+     */
+    private static double innerCircleRadius(double outerCircleRadius, float batteryPct) {
+        return outerCircleRadius*Math.sqrt(batteryPct);
     }
 }


### PR DESCRIPTION
Currently the radius of the inner battery circle is calculated by multiplying
it by the battery fraction directly. This results in the circle looking
smaller than expected because the area is smaller.

For example, when the battery is at 50% the battery fraction is 0.5.
The area of the outer circle is Pi_r.
The area of the inner circle is Pi_r_(0.5)^2 which is Pi_r*0.25.
So the area of the inner circle is 25% of the outer circle instead of 50%.

This changes the calculation so that the inner circle area reflects the battery
percentage instead of the radius.

Tested on a Nexus 5X running Marshmellow.

Related issue: #6
