### PR TITLE
Use ACTION_CHANGE_LIVE_WALLPAPER for the Set Wallpaper button.

### DIFF
--- a/app/src/main/java/com/androidexperiments/meter/MainActivity.java
+++ b/app/src/main/java/com/androidexperiments/meter/MainActivity.java
@@ -2,6 +2,7 @@ package com.androidexperiments.meter;
 
 import android.app.Activity;
 import android.app.WallpaperManager;
+import android.content.ComponentName;
 import android.content.Intent;
 import android.graphics.Typeface;
 import android.os.Bundle;
@@ -53,7 +54,9 @@ public class MainActivity extends Activity {
         mSetWallpaperBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent intent = new Intent(WallpaperManager.ACTION_LIVE_WALLPAPER_CHOOSER);
+                Intent intent = new Intent(WallpaperManager.ACTION_CHANGE_LIVE_WALLPAPER);
+                intent.putExtra(WallpaperManager.EXTRA_LIVE_WALLPAPER_COMPONENT,
+                        new ComponentName(getApplication(), MeterWallpaper.class));
                 startActivity(intent);
             }
         });


### PR DESCRIPTION
Also set the extra EXTRA_LIVE_WALLPAPER_COMPONENT so that a preview of the
Meter wallpaper is shown directly instead of showing a list of all live
wallpapers.

Tested on a Nexus 5X with Marshmallow and Google Now Launcher.

I haven't tested this on other launchers so I'm not sure how widespread support for
ACTION_CHANGE_LIVE_WALLPAPER is or whether that's important :)
